### PR TITLE
VCST-4746: Test workflow from branch

### DIFF
--- a/.github/workflows/module-ci.yml
+++ b/.github/workflows/module-ci.yml
@@ -364,13 +364,12 @@ jobs:
       && github.event_name == 'push'
       && needs.ci.outputs.deployment-folder-exists == 'true'}}
     needs: ci
-    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.25
+    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@VCST-4746 #v3.800.25
     with:
       releaseSource: module
       moduleId: ${{ needs.ci.outputs.moduleId }}
       moduleVer: ${{ needs.ci.outputs.version }}
       moduleBlob: ${{ needs.ci.outputs.blobId }}
       jiraKeys: ${{ needs.ci.outputs.jira-keys }}
-      argoServer: 'argo.virtocommerce.cloud'
       matrix: '{"include":${{ needs.ci.outputs.matrix }}}'
     secrets: inherit


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link:
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.EventBus_3.1003.0-pr-29-221c.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `deploy-cloud` job to run against a branch ref of the shared `deploy-cloud.yml` workflow instead of the pinned release tag, which could alter deployment behavior for `main/master/dev` pushes. Risk is limited to CI/CD execution but affects production deployment automation.
> 
> **Overview**
> Updates the GitHub Actions `deploy-cloud` job in `module-ci.yml` to use `VirtoCommerce/.github` workflow ref `@VCST-4746` (instead of the pinned `@v3.800.25`) and drops the explicit `argoServer` input, relying on the shared workflow defaults.
> 
> Also fixes the job block formatting (ensuring `secrets: inherit` is present and the file ends with a newline).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 221cda70e1d5234d87e99935c60910012c4fd7dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->