### PR TITLE
VCST-5032: CloudEvent data payload values are empty arrays when a PayloadTransformationTemplate is set

### DIFF
--- a/src/VirtoCommerce.EventBusModule.Data/Services/AzureEventBusProvider.cs
+++ b/src/VirtoCommerce.EventBusModule.Data/Services/AzureEventBusProvider.cs
@@ -38,52 +38,7 @@ namespace VirtoCommerce.EventBusModule.Data.Services
 
             try
             {
-                foreach (var @event in events)
-                {
-                    // Currently, AzureEventBusProvider does not have azure-specific event translation settings.
-                    // Here we can add those in the future if needed.
-                    // To allow this you should make a descendant from ProviderSpecificEventSettings,
-                    // then add deserialization from @event.Subscription.EventSettings
-
-                    var subscription = @event.Subscription;
-                    var subscriptionName = subscription?.Name ?? nameof(AzureEventBusProvider);
-                    var eventId = @event.Payload.EventId;
-                    var eventData = @event.Payload.Arg;
-
-                    var eventDataItems = new List<object>();
-
-                    if (string.IsNullOrEmpty(subscription?.PayloadTransformationTemplate) && eventData is IEvent nativeEvent)
-                    {
-                        // Implement default behavior equal to previous version of event bus module (compatibility)
-
-                        // Entities
-                        eventDataItems.AddRange(nativeEvent
-                            .GetObjectsWithDerived<IEntity>()
-                            .Select(x => new
-                            {
-                                EventId = eventId,
-                                ObjectId = x.Id,
-                                ObjectType = x.GetType().FullName,
-                            }));
-
-                        // Value objects
-                        eventDataItems.AddRange(nativeEvent
-                            .GetObjectsWithDerived<ValueObject>()
-                            .Select(x => new
-                            {
-                                EventId = eventId,
-                                ObjectId = x.GetCacheKey(),
-                                ObjectType = x.GetType().FullName,
-                            }));
-                    }
-
-                    if (eventDataItems.Count == 0)
-                    {
-                        eventDataItems.Add(eventData);
-                    }
-
-                    cloudEvents.AddRange(eventDataItems.Select(x => new CloudEvent(subscriptionName, eventId, x)));
-                }
+                cloudEvents = BuildCloudEvents(events);
 
                 var eventGridResponse = await _client.SendEventsAsync(cloudEvents);
 
@@ -102,6 +57,60 @@ namespace VirtoCommerce.EventBusModule.Data.Services
             return result;
         }
 
+        protected virtual List<CloudEvent> BuildCloudEvents(IEnumerable<Event> events)
+        {
+            var cloudEvents = new List<CloudEvent>();
+
+            foreach (var @event in events)
+            {
+                // Currently, AzureEventBusProvider does not have azure-specific event translation settings.
+                // Here we can add those in the future if needed.
+                // To allow this you should make a descendant from ProviderSpecificEventSettings,
+                // then add deserialization from @event.Subscription.EventSettings
+
+                var subscription = @event.Subscription;
+                var subscriptionName = subscription?.Name ?? nameof(AzureEventBusProvider);
+                var eventId = @event.Payload.EventId;
+                var eventData = @event.Payload.Arg;
+
+                var eventDataItems = new List<object>();
+
+                if (string.IsNullOrEmpty(subscription?.PayloadTransformationTemplate) && eventData is IEvent nativeEvent)
+                {
+                    // Implement default behavior equal to previous version of event bus module (compatibility)
+
+                    // Entities
+                    eventDataItems.AddRange(nativeEvent
+                        .GetObjectsWithDerived<IEntity>()
+                        .Select(x => new
+                        {
+                            EventId = eventId,
+                            ObjectId = x.Id,
+                            ObjectType = x.GetType().FullName,
+                        }));
+
+                    // Value objects
+                    eventDataItems.AddRange(nativeEvent
+                        .GetObjectsWithDerived<ValueObject>()
+                        .Select(x => new
+                        {
+                            EventId = eventId,
+                            ObjectId = x.GetCacheKey(),
+                            ObjectType = x.GetType().FullName,
+                        }));
+                }
+
+                if (eventDataItems.Count == 0)
+                {
+                    eventDataItems.Add(eventData);
+                }
+
+                cloudEvents.AddRange(eventDataItems.Select(x => BuildCloudEvent(subscriptionName, eventId, x)));
+            }
+
+            return cloudEvents;
+        }
+
         public override void SetConnectionOptions(JObject options)
         {
             ArgumentNullException.ThrowIfNull(options);
@@ -109,6 +118,27 @@ namespace VirtoCommerce.EventBusModule.Data.Services
             var evtGridOptions = options.ToObject<AzureEventGridOptions>();
 
             _client = new EventGridPublisherClient(new Uri(evtGridOptions.ConnectionString), new AzureKeyCredential(evtGridOptions.AccessKey));
+        }
+
+        protected virtual CloudEvent BuildCloudEvent(string subscriptionName, string eventId, object eventData)
+        {
+            // The templated path in DefaultEventBusSubscriptionsManager produces a JToken
+            // (JsonConvert.DeserializeObject(string) returns JObject/JArray/JValue).
+            // CloudEvent serializes `data` with System.Text.Json, which has no converter for
+            // Newtonsoft's JToken — primitive JValues serialize as []. Send the rendered JSON
+            // verbatim as BinaryData to bypass STJ on the templated path.
+            if (eventData is JToken jt)
+            {
+                var json = jt.ToString(Newtonsoft.Json.Formatting.None);
+                return new CloudEvent(
+                    subscriptionName,
+                    eventId,
+                    BinaryData.FromString(json),
+                    "application/json",
+                    CloudEventDataFormat.Json);
+            }
+
+            return new CloudEvent(subscriptionName, eventId, eventData);
         }
     }
 }

--- a/src/VirtoCommerce.EventBusModule.Data/Services/AzureEventBusProvider.cs
+++ b/src/VirtoCommerce.EventBusModule.Data/Services/AzureEventBusProvider.cs
@@ -38,7 +38,7 @@ namespace VirtoCommerce.EventBusModule.Data.Services
 
             try
             {
-                cloudEvents = BuildCloudEvents(events);
+                BuildCloudEvents(events, cloudEvents);
 
                 var eventGridResponse = await _client.SendEventsAsync(cloudEvents);
 
@@ -57,10 +57,8 @@ namespace VirtoCommerce.EventBusModule.Data.Services
             return result;
         }
 
-        protected virtual List<CloudEvent> BuildCloudEvents(IEnumerable<Event> events)
+        protected virtual void BuildCloudEvents(IEnumerable<Event> events, List<CloudEvent> cloudEvents)
         {
-            var cloudEvents = new List<CloudEvent>();
-
             foreach (var @event in events)
             {
                 // Currently, AzureEventBusProvider does not have azure-specific event translation settings.
@@ -107,8 +105,6 @@ namespace VirtoCommerce.EventBusModule.Data.Services
 
                 cloudEvents.AddRange(eventDataItems.Select(x => BuildCloudEvent(subscriptionName, eventId, x)));
             }
-
-            return cloudEvents;
         }
 
         public override void SetConnectionOptions(JObject options)

--- a/tests/VirtoCommerce.EventBusModule.Tests/AzureEventBusProviderSerializationTests.cs
+++ b/tests/VirtoCommerce.EventBusModule.Tests/AzureEventBusProviderSerializationTests.cs
@@ -1,0 +1,107 @@
+using System.Collections.Generic;
+using Azure.Messaging;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using VirtoCommerce.EventBusModule.Core.Models;
+using VirtoCommerce.EventBusModule.Data.Services;
+using Xunit;
+
+namespace VirtoCommerce.EventBusModule.Tests
+{
+    public class AzureEventBusProviderSerializationTests
+    {
+        private const string RenderedJson =
+            @"{""productId"":""abc"",""fulfillmentCenterId"":""ffc-1"",""status"":""LowStock"",""quantity"":42,""nested"":{""inner"":""value""}}";
+
+        // Reproduces the templated path from DefaultEventBusSubscriptionsManager.SendEvent —
+        // a JObject (the result of JsonConvert.DeserializeObject(scribanRender)) is fed in as
+        // EventPayload.Arg with a non-empty PayloadTransformationTemplate, then the full
+        // BuildCloudEvents loop is executed exactly as production runs it. Without the fix
+        // (i.e. before the JToken branch in BuildCloudEvent) this test fails: every primitive
+        // serializes as [] because Azure.Messaging.CloudEvent serializes `data` with STJ,
+        // which has no converter for Newtonsoft's JToken/JValue.
+        [Fact]
+        public void BuildCloudEvents_TemplatedJObjectPayload_PreservesPrimitives()
+        {
+            var provider = new TestableProvider();
+            var jobject = (JObject)JsonConvert.DeserializeObject(RenderedJson)!;
+
+            var cloudEvents = provider.Build(new[]
+            {
+                new Event
+                {
+                    Subscription = new Subscription
+                    {
+                        Name = "test-sub",
+                        PayloadTransformationTemplate = "{ \"productId\": \"{{ ProductId }}\" }",
+                    },
+                    Payload = new EventPayload { EventId = "test-event", Arg = jobject },
+                },
+            });
+
+            var ce = Assert.Single(cloudEvents);
+            var serialized = ce.Data!.ToString();
+
+            Assert.DoesNotContain("[]", serialized);
+            Assert.Contains("\"productId\":\"abc\"", serialized);
+            Assert.Contains("\"fulfillmentCenterId\":\"ffc-1\"", serialized);
+            Assert.Contains("\"status\":\"LowStock\"", serialized);
+            Assert.Contains("\"quantity\":42", serialized);
+            Assert.Contains("\"nested\":{\"inner\":\"value\"}", serialized);
+            Assert.Equal("application/json", ce.DataContentType);
+        }
+
+        [Fact]
+        public void BuildCloudEvents_TemplatedJArrayPayload_PreservesValues()
+        {
+            var provider = new TestableProvider();
+            var jarray = (JArray)JsonConvert.DeserializeObject(@"[""one"",""two"",3]")!;
+
+            var cloudEvents = provider.Build(new[]
+            {
+                new Event
+                {
+                    Subscription = new Subscription
+                    {
+                        Name = "test-sub",
+                        PayloadTransformationTemplate = "[ ... ]",
+                    },
+                    Payload = new EventPayload { EventId = "test-event", Arg = jarray },
+                },
+            });
+
+            var ce = Assert.Single(cloudEvents);
+            Assert.Equal("application/json", ce.DataContentType);
+            Assert.Equal(@"[""one"",""two"",3]", ce.Data!.ToString());
+        }
+
+        // Default-template path (no PayloadTransformationTemplate, payload is a plain CLR object)
+        // must keep using the object overload of CloudEvent and serialize via STJ as before.
+        [Fact]
+        public void BuildCloudEvents_NonTemplatedPlainObjectPayload_UsesObjectOverload()
+        {
+            var provider = new TestableProvider();
+            var record = new { EventId = "evt-1", ObjectId = "obj-1", ObjectType = "TestType" };
+
+            var cloudEvents = provider.Build(new[]
+            {
+                new Event
+                {
+                    Subscription = new Subscription { Name = "test-sub" }, // no template
+                    Payload = new EventPayload { EventId = "evt-1", Arg = record },
+                },
+            });
+
+            var ce = Assert.Single(cloudEvents);
+            var serialized = ce.Data!.ToString();
+            Assert.Contains("\"EventId\":\"evt-1\"", serialized);
+            Assert.Contains("\"ObjectId\":\"obj-1\"", serialized);
+            Assert.Contains("\"ObjectType\":\"TestType\"", serialized);
+        }
+
+        private sealed class TestableProvider : AzureEventBusProvider
+        {
+            public List<CloudEvent> Build(IEnumerable<Event> events) => BuildCloudEvents(events);
+        }
+    }
+}

--- a/tests/VirtoCommerce.EventBusModule.Tests/AzureEventBusProviderSerializationTests.cs
+++ b/tests/VirtoCommerce.EventBusModule.Tests/AzureEventBusProviderSerializationTests.cs
@@ -101,7 +101,12 @@ namespace VirtoCommerce.EventBusModule.Tests
 
         private sealed class TestableProvider : AzureEventBusProvider
         {
-            public List<CloudEvent> Build(IEnumerable<Event> events) => BuildCloudEvents(events);
+            public List<CloudEvent> Build(IEnumerable<Event> events)
+            {
+                var list = new List<CloudEvent>();
+                BuildCloudEvents(events, list);
+                return list;
+            }
         }
     }
 }


### PR DESCRIPTION
## Description
fix: EventBus: CloudEvent data payload values are empty arrays when a PayloadTransformationTemplate is set

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5032
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.EventBus_3.1007.0-pr-31-e20c.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Azure Event Grid payload serialization when `PayloadTransformationTemplate` produces Newtonsoft `JToken` values; incorrect handling could impact downstream consumers expecting specific JSON shapes. Scope is localized and covered by new serialization-focused unit tests.
> 
> **Overview**
> Fixes Azure Event Grid publishing when a `PayloadTransformationTemplate` is used by ensuring templated `JObject`/`JArray` payloads are sent as raw JSON (`BinaryData` + `application/json`) instead of being re-serialized by `System.Text.Json` (which was turning primitive values into empty arrays).
> 
> Refactors `AzureEventBusProvider.SendEventsAsync` to delegate CloudEvent creation to new overridable `BuildCloudEvents`/`BuildCloudEvent` methods, and adds unit tests covering templated `JToken` payloads plus the non-templated object path to prevent regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e20c1e5443f9bc940e49c06f96b23c7c85abf7d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->